### PR TITLE
praxisdigital/moodle-opgaver#501 - Skip files larger than 100 MB

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1442,6 +1442,14 @@ function urkund_send_file_to_urkund($plagiarismfile, $plagiarismsettings, $file)
         $DB->update_record('plagiarism_urkund_files', $plagiarismfile);
         return true;
     }
+
+    if ($file->get_filesize() > 100 * 1024 ** 2) { // File is larger than 100 MB, marking to large and skipping.
+        mtrace("URKUND fileid:".$plagiarismfile->id. ' is to large, skipping...');
+        $plagiarismfile->statuscode = URKUND_STATUSCODE_TOO_LARGE;
+        $DB->update_record('plagiarism_urkund_files', $plagiarismfile);
+        return true;
+    }
+
     mtrace("URKUND fileid:".$plagiarismfile->id. ' sending to URKUND');
     if (!empty($plagiarismfile->relateduserid)) {
         $useremail = $DB->get_field('user', 'email', array('id' => $plagiarismfile->relateduserid));

--- a/lib.php
+++ b/lib.php
@@ -1443,7 +1443,8 @@ function urkund_send_file_to_urkund($plagiarismfile, $plagiarismsettings, $file)
         return true;
     }
 
-    if ($file->get_filesize() > 100 * 1024 ** 2) { // File is larger than 100 MB, marking to large and skipping.
+    $filesize = (!empty($file->filepath)) ? filesize($file->filepath) : $file->get_filesize();
+    if ($filesize > 100 * 1024 ** 2) { // File is larger than 100 MB, marking to large and skipping.
         mtrace("URKUND fileid:".$plagiarismfile->id. ' is to large, skipping...');
         $plagiarismfile->statuscode = URKUND_STATUSCODE_TOO_LARGE;
         $DB->update_record('plagiarism_urkund_files', $plagiarismfile);

--- a/urkund_debug.php
+++ b/urkund_debug.php
@@ -169,8 +169,14 @@ if (!empty($delete) && confirm_sesskey()) {
 
 $table = new \plagiarism_urkund\output\debug_table('debugtable');
 
-$userfields = get_all_user_name_fields(true, 'u');
-$sqlfields = "t.*, ".$userfields.", m.name as moduletype, ".
+//$userfields = get_all_user_name_fields(true, 'u');
+use core_user\fields;
+
+$userfieldsapi = fields::for_name();
+$userfields = $userfieldsapi->get_required_fields();
+$userfieldsstring = implode(',', $userfields);
+
+$sqlfields = "t.*, ".$userfieldsstring.", m.name as moduletype, ".
     "cm.course as courseid, cm.instance as cminstance, c.fullname, c.shortname";
 $sqlfrom = "{plagiarism_urkund_files} t, {user} u, {modules} m, {course_modules} cm, {course} c ";
 $sqlwhere = "m.id = cm.module AND cm.id = t.cm AND t.userid = u.id AND c.id = cm.course AND t.statuscode <> 'Analyzed'";

--- a/version.php
+++ b/version.php
@@ -25,9 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023071900;
+/** @var object $plugin */
+$plugin->component = 'plagiarism_urkund';
+$plugin->version = 2024103000;
 $plugin->requires = 2022041900; // Requires 4.0.
 $plugin->cron     = 0; // Cron function no longer used.
-$plugin->component = 'plagiarism_urkund';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '4.0.3';
+$plugin->release   = '4.0.4';

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var object $plugin */
 $plugin->component = 'plagiarism_urkund';
-$plugin->version = 2024103000;
+$plugin->version = 2024110600;
 $plugin->requires = 2022041900; // Requires 4.0.
 $plugin->cron     = 0; // Cron function no longer used.
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023071900;
+$plugin->version = 2024092700;
 $plugin->requires = 2022041900; // Requires 4.0.
 $plugin->cron     = 0; // Cron function no longer used.
 $plugin->component = 'plagiarism_urkund';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '4.0.3';
+$plugin->release   = '4.0.4';


### PR DESCRIPTION
We have an issue where the plagiarism plugin tries to send some very large files to the checker. We're talking multiple gigabytes. This causes an out of memory fatal error since the file content is being loaded into memory, before sending to the checker.

I then looked up your file requirements and found that you limit it at 100 MB and thought why not skip them before attempting to send them forward :)

Feel free to reply with any wanted changes from my part :)